### PR TITLE
Feature/add blog boilerplate

### DIFF
--- a/data/blog/the-webs-last-mile.mdx
+++ b/data/blog/the-webs-last-mile.mdx
@@ -1,0 +1,46 @@
+---
+title: The Web's Last Mile
+date: '2021-12-03'
+tags: ['Web Challenges In The 20s', 'web last mile', 'tincre', 'web-scale-problems']
+draft: false
+summary: How we're growing Tincre to focus on the web's last mile.
+images:
+  [
+    'https://res.cloudinary.com/tincre/image/upload/v1638498331/slightlysharpe.com/AdobeStock_214448694_lhgjwv_lr8sje_ok1pog.jpg',
+  ]
+authors: ['default']
+layout: PostLayout
+---
+
+_This was initially posted on Tincre's [Slightly Sharpe blog](https://slightlysharpe.com/blog/the-webs-last-mile) and co-authored by [Philip Muellerschoen](https://twitter.com/philipmuh)._
+
+<Image
+  className="rounded-md"
+  src="https://res.cloudinary.com/tincre/image/upload/v1638498331/slightlysharpe.com/AdobeStock_214448694_lhgjwv_lr8sje_ok1pog.jpg"
+  alt="Miniature, colorful shopping bags sit on top of a glossy, pink phone. The background is of charts and graphs, somewhat like a printed Excel file."
+  height={1000}
+  width={2000}
+/>
+
+While the flow of information on the web is nearly ubiquitous, financial innovation is still in its infancy. Current innovations have radically upgraded the financial infrastructure across the web. But fundamental end-user product innovations, that build-in financial services, for content creators, businesses, and, more generally, interaction producers, are lacking.
+
+_People who do things online need better ways to monetize those things_.
+
+## Infrastructure innovation
+
+Early fintech pioneers like [Paypal](https://paypal.com), [Stripe](https://stripe.com), [Block (formerly Square)](https://squareup.com), and [Plaid](https://plaid.com) have taken formidable first steps, developing solutions surrounding the basic infrastructure of consumer and business financial services. Another trailblazer is [Affirm](https://affirm.com), a company generalizing the basic process of lending to consumers through business financial services.
+
+However, the pie is much bigger than that. Here’s an eye-opening stat: Facebook, the product, and Google Search generated five trillion consumer ad interactions in Q2 of 2021, according to some back of the napkin math using prices we found from the brand agency [Topdraw](https://www.topdraw.com/insights/is-online-advertising-expensive/). Accessing multiple platforms’ users is still a precarious, difficult process, and an expensive job for most businesses, let alone for even medium-sized corporate marketing departments. Great tools exist to help bigger teams but few exist to make it easy for the rest of us - the individual creator or small business - to cheaply, easily, and effectively monetize interactions.
+
+## Interaction monetization innovation
+
+We see the ex-platform monetization of interactions - by producers of interactions - as one of the fundamental technological problems of the next decade with nascent solutions on offer today. Two distinct categories describe the web’s last mile problem.
+
+1. Infrastructure
+2. Interaction monetization
+
+Our first concerted attack at interaction monetization directly is [b00st.com](https://b00st.com). In its first seven months, it brought its users 200-300% increases in the value of their ad spends, as measured against those numbers above. We’re scaling our ad technology across industries, bringing a concerted focus to improving interaction monetization all over the web. We're doing this in ads first, but many more types of consumption interaction solutions will follow.
+
+## Bridging the two
+
+Our products and services, like many of our client users’ businesses, leverage greatly the improved financial infrastructure innovations great companies continue to foster. The web’s last mile is a problem of helping people monetize their ingenuity, productivity, and hard work. As we see it, the problem’s first segment, infrastructure, is being tackled mightily and well. We’re tackling the interaction monetization segment, by acting as both a bridge between the two through our Developer Platform, [Bit Modulus](https://bitmodulus.com), and directly improving interaction monetization through subsidiary software service brands, like [b00st.com](https://b00st.com).

--- a/next.config.js
+++ b/next.config.js
@@ -53,6 +53,9 @@ const securityHeaders = [
 ]
 
 module.exports = withBundleAnalyzer({
+  images: {
+    domains: ['res.cloudinary.com'],
+  },
   reactStrictMode: true,
   pageExtensions: ['js', 'jsx', 'md', 'mdx'],
   eslint: {


### PR DESCRIPTION
This adds back the `data/blog` directory with one article, for now.