### PR TITLE
:label: add canonicalUrl to frontmatter for slightlysharpe.com piece

### DIFF
--- a/data/blog/the-webs-last-mile.mdx
+++ b/data/blog/the-webs-last-mile.mdx
@@ -3,6 +3,7 @@ title: The Web's Last Mile
 date: '2021-12-03'
 tags: ['Web Challenges In The 20s', 'web last mile', 'tincre', 'web-scale-problems']
 draft: false
+canonicalUrl: https://slightlysharpe.com/blog/the-webs-last-mile
 summary: How we're growing Tincre to focus on the web's last mile.
 images:
   [


### PR DESCRIPTION
This should keep Google and other search bots from labeling the url junk.